### PR TITLE
Adding hash post array

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ to update an existing record:
 data = {record_id: 3, name: 'this is a test to update', field_2: Date.today}
 r.post(data) # this will update the record with record_id 3. if record_id 3 does not exist it will create an entry with that record id
 
+There is also a helper class added to ruby Hash allowing you to convert a ruby array to a http-post style array. I created this after having some issues filtering on 'forms' and 'fields'
+Example:
+params = {:fields => ['record_id', 'lab_id'], :forms => ['slide_tracking', 'id_shipping']} # This is the data I want to send to RedcapAPI, limiting the fields and forms
+r.export_metadata(params.to_http_post_array()) # This gets the metadata for only those fields/forms by using the newly added method on Hash 'to_http_post_array'.
+
 ## Contributing
 
 1. Fork it ( https://github.com/[my-github-username]/RedcapAPI/fork )

--- a/RedcapAPI.gemspec
+++ b/RedcapAPI.gemspec
@@ -43,5 +43,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "mechanize"
+  spec.add_dependency "mechanize"
+  spec.add_dependency "json"
 end

--- a/lib/RedcapAPI.rb
+++ b/lib/RedcapAPI.rb
@@ -1,6 +1,24 @@
 require "RedcapAPI/version"
 require "json"
 require "mechanize"
+  class Hash
+    def to_http_post_array
+      r = {}
+
+      self.each_key do |k|
+        if (false == self[k].is_a?(Array))
+          raise "!ERROR: Expecting hash value to be an Array."
+        end
+
+        self[k].each_with_index do |v,i|
+          r["#{k}[#{i}]"] = v
+        end
+      end
+
+      return r
+    end
+  end
+
   class RedcapAPI
     DEFAULT_PARAMS = {
       :content => 'record',

--- a/lib/RedcapAPI.rb
+++ b/lib/RedcapAPI.rb
@@ -1,4 +1,6 @@
 require "RedcapAPI/version"
+require "json"
+require "mechanize"
   class RedcapAPI
     def initialize(token, url)
       @url = url

--- a/lib/RedcapAPI/version.rb
+++ b/lib/RedcapAPI/version.rb
@@ -1,3 +1,3 @@
 class RedcapAPI
-  VERSION = "0.0.5b"
+  VERSION = "0.0.6"
 end


### PR DESCRIPTION
Okay, sorry to break these into so many pull request but I wanted you to be able to see them as different features in case you didn't agree with one of them. This one adds a helper to Hash so that users can convert to POST arrays. I came across this when I was trying to call the RedcapAPI and didn't know the format to send an array. I added the example in the README for the case I was trying to solve.
