### PR TITLE
User defined parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This gem is still under active development. Please contact me directly with any 
   
 To start:
 
-r = RedcapAPI.new(token, url) # your institution has it's own url, and each project has it's own token
+r = RedcapAPI.new(token, url, parser) # your institution has it's own url, and each project has it's own token, an optional 'parser' that defaults to JSON. See the test cases for how to use other parsers like Nokogiri::XML and CSV.
 
 r.export(optional params) # returns all records in JSON format, provide additional hash of parameters in you want to override or add any additional RedcapAPI options.
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ to update an existing record:
 data = {record_id: 3, name: 'this is a test to update', field_2: Date.today}
 r.post(data) # this will update the record with record_id 3. if record_id 3 does not exist it will create an entry with that record id
 
+There is also a helper class added to ruby Hash allowing you to convert a ruby array to a http-post style array. I created this after having some issues filtering on 'forms' and 'fields'
+Example:
+params = {:fields => ['record_id', 'lab_id'], :forms => ['slide_tracking', 'id_shipping']} # This is the data I want to send to RedcapAPI, limiting the fields and forms
+r.export_metadata(params.to_http_post_array()) # This gets the metadata for only those fields/forms by using the newly added method on Hash 'to_http_post_array'.
+
 ## Contributing
 
 1. Fork it ( https://github.com/[my-github-username]/RedcapAPI/fork )

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,9 @@
 require "bundler/gem_tasks"
+require 'rake/testtask'
 
+Rake::TestTask.new do |t|
+  t.libs << 'test'
+end
+
+desc "Run tests"
+task :default => :test

--- a/RedcapAPI.gemspec
+++ b/RedcapAPI.gemspec
@@ -43,6 +43,8 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "csv"
+  spec.add_development_dependency "nokogiri"
   spec.add_dependency "mechanize"
   spec.add_dependency "json"
 end

--- a/RedcapAPI.gemspec
+++ b/RedcapAPI.gemspec
@@ -43,5 +43,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "mechanize"
+  spec.add_dependency "mechanize"
+  spec.add_dependency "json"
 end

--- a/lib/RedcapAPI.rb
+++ b/lib/RedcapAPI.rb
@@ -26,14 +26,15 @@ require "mechanize"
       :type    => 'flat'
     }
 
-    def initialize(token, url)
+    def initialize(token, url, format = JSON)
       @url     = url
       @payload = DEFAULT_PARAMS
       @payload[:token] = token
+      @format  = format
     end
 
     def get(record_id = nil)
-      data = JSON.parse Mechanize.new.post(@url, @payload).body
+      data = self.export()
       if record_id
         data = data.select{|x| x['record_id'] == record_id.to_s}
       end
@@ -82,7 +83,7 @@ require "mechanize"
     end
 
     def export(params = {})
-      return JSON.parse(api(params))
+      return @format.parse(api(params))
     end
 
     def export_metadata(params = {})

--- a/lib/RedcapAPI.rb
+++ b/lib/RedcapAPI.rb
@@ -1,6 +1,24 @@
 require "RedcapAPI/version"
 require "json"
 require "mechanize"
+  class Hash
+    def to_http_post_array
+      r = {}
+
+      self.each_key do |k|
+        if (false == self[k].is_a?(Array))
+          raise "!ERROR: Expecting hash value to be an Array."
+        end
+
+        self[k].each_with_index do |v,i|
+          r["#{k}[#{i}]"] = v
+        end
+      end
+
+      return r
+    end
+  end
+
   class RedcapAPI
     DEFAULT_PARAMS = {
       :content => 'record',

--- a/lib/RedcapAPI.rb
+++ b/lib/RedcapAPI.rb
@@ -26,11 +26,11 @@ require "mechanize"
       :type    => 'flat'
     }
 
-    def initialize(token, url, format = JSON)
+    def initialize(token, url, parser = JSON)
       @url     = url
       @payload = DEFAULT_PARAMS
       @payload[:token] = token
-      @format  = format
+      @parser  = parser
     end
 
     def get(record_id = nil)
@@ -83,7 +83,7 @@ require "mechanize"
     end
 
     def export(params = {})
-      return @format.parse(api(params))
+      return @parser.parse(api(params))
     end
 
     def export_metadata(params = {})

--- a/lib/RedcapAPI.rb
+++ b/lib/RedcapAPI.rb
@@ -1,4 +1,6 @@
 require "RedcapAPI/version"
+require "json"
+require "mechanize"
   class RedcapAPI
     def initialize(token, url)
       @url = url

--- a/lib/RedcapAPI/version.rb
+++ b/lib/RedcapAPI/version.rb
@@ -1,3 +1,3 @@
 class RedcapAPI
-  VERSION = "0.0.5b"
+  VERSION = "0.0.6"
 end

--- a/test/test_redcap_api.rb
+++ b/test/test_redcap_api.rb
@@ -1,0 +1,105 @@
+require 'test/unit'
+require 'RedcapAPI'
+require 'csv'
+require 'Nokogiri'
+
+class Hash
+  def body
+    return self[:body]
+  end
+end
+
+class Mechanize
+  def post(url, payload)
+    v = {}
+
+    if ('json' == payload[:format])
+      if ('metadata' == payload[:content])
+        v[:body] = '[{"field_name":"record_id", "form_name":"form0"},{"field_name":"first_name", "form_name":"form0"},{"field_name":"trc_id", "form_name":"form0"}]'
+      else
+        v[:body] = '[{"record_id":"1", "trc_id":"b", "first_name":"bob"},{"record_id":"2", "trc_id":"c", "first_name":"chris"}]'
+      end
+    elsif ('xml' == payload[:format])
+      v[:body] = '<?xml version="1.0" encoding="UTF-8" ?><records><item><record_id><![CDATA[1]]></record_id><trc_id>b</trc_id><first_name>bob</first_name></item><item><record_id><![CDATA[2]]></record_id><trc_id>c</trc_id><first_name>chris</first_name></item></records>'
+    elsif ('csv' == payload[:format])
+      v[:body] = 'record_id,trc_id,first_name'
+      v[:body] << "\n"
+      v[:body] << '"1","b","bob"'
+      v[:body] << "\n"
+      v[:body] << '"2","c","chris"'
+    else
+      raise "!ERROR: unkown format '#{payload[:format]}'."
+    end
+
+    return v
+  end
+end
+
+class RedcapAPITest < Test::Unit::TestCase
+  def test_hash_extension
+    t = {:a => [1,2,3], :b => ["h", "i", "j"]}
+    e = {"a[0]" => 1, "a[1]" => 2, "a[2]" => 3, "b[0]" => "h", "b[1]" => "i", "b[2]" => "j"}
+    assert_equal(e, t.to_http_post_array)
+  end
+
+  def test_default_parser
+    default   = RedcapAPI.new("", "").export()
+    json_data = RedcapAPI.new("", "", JSON).export({:format => 'json'})
+
+    assert_equal(json_data, default)
+  end
+
+  def test_xml_parser
+    xml_data  = RedcapAPI.new("", "", Nokogiri::XML::Document).export({:format => 'xml'})
+    json_data = RedcapAPI.new("", "", JSON).export({:format => 'json'})
+    xml_to_json_data = []
+
+    xml_data.xpath(".//item").each do |item_node|
+      json_record = {}
+      item_node.children().each do |value_node|
+        json_record[value_node.name()] = value_node.content()
+      end
+      xml_to_json_data << json_record
+    end
+
+    assert_equal(json_data, xml_to_json_data)
+  end
+
+  def test_csv_parser
+    csv_data  = RedcapAPI.new("", "", CSV).export({:format => 'csv'})
+    json_data = RedcapAPI.new("", "", JSON).export({:format => 'json'})
+    csv_to_json_data = []
+
+    csv_data.each_with_index do |record,i|
+      if (0 != i)
+        json_record = {}
+        record.each_with_index do |value,j|
+          json_record[csv_data[0][j]] = value
+        end
+        csv_to_json_data << json_record
+      end
+    end
+
+    assert_equal(json_data, csv_to_json_data)
+  end
+
+  def test_param_override
+    metadata = RedcapAPI.new("", "").export_metadata()
+    data     = RedcapAPI.new("", "").export_metadata({:content => 'record'})
+
+    assert_not_equal(data, metadata)
+  end
+
+  def test_metadata
+    metadata = RedcapAPI.new("", "").export_metadata()
+    data = [{"field_name"=>"record_id", "form_name"=>"form0"},{"field_name"=>"first_name", "form_name"=>"form0"},{"field_name"=>"trc_id", "form_name"=>"form0"}]
+
+    assert_equal(data, metadata)
+  end
+
+  def test_get_fields
+    fields = RedcapAPI.new("", "").get_fields()
+
+    assert_equal(["record_id", "first_name", "trc_id"], fields)
+  end
+end


### PR DESCRIPTION
Last one! So, I added the ability to pass in the parser that you want so user's can specify XML or CSV instead of JSON. They still have to override the 'format' parameter because I didn't want to force a dependency on Nokogiri since I think most will use JSON.

I also added test cases for all my new code and a couple of the methods you had originally created. I wasn't sure exactly how to test the next record and filter_date and post methods since I don't really use the 'import' functionality of the RedcapAPI.

Thanks so much!
